### PR TITLE
Moving initialisation of helper values to decide when setting initial scale

### DIFF
--- a/L.D3SvgOverlay.js
+++ b/L.D3SvgOverlay.js
@@ -103,12 +103,7 @@ L.D3SvgOverlay = (L.version < "1.0" ? L.Class : L.Layer).extend({
         this.selection = this._rootGroup;
 
         // Init shift/scale invariance helper values
-        this._pixelOrigin = map.getPixelOrigin();
-        this._wgsOrigin = L.latLng([0, 0]);
-        this._wgsInitialShift = this.map.latLngToLayerPoint(this._wgsOrigin);
-        this._zoom = this.map.getZoom();
-        this._shift = L.point(0, 0);
-        this._scale = 1;
+        this.initHelperValues();
 
         // Create projection object
         this.projection = {
@@ -161,6 +156,16 @@ L.D3SvgOverlay = (L.version < "1.0" ? L.Class : L.Layer).extend({
     addTo: function (map) {
         map.addLayer(this);
         return this;
+    },
+
+    initHelperValues: function() {
+        // Init shift/scale invariance helper values
+        this._pixelOrigin = this.map.getPixelOrigin();
+        this._wgsOrigin = L.latLng([0, 0]);
+        this._wgsInitialShift = this.map.latLngToLayerPoint(this._wgsOrigin);
+        this._zoom = this.map.getZoom();
+        this._shift = L.point(0, 0);
+        this._scale = 1;
     }
 
 });


### PR DESCRIPTION
Hello,

First, thank you for this library, it helps me a lot for using d3 with leaflet.

I've encountered a difficulty when I wanted to set the initial scale.

I think it would be useful to separate the block who set properties used to calculate scale & translation in `_zoomChange` method.

It helps me to let the user of the map say to the overlay, 'ok, now it's scale 1'.

My use case is an app where user draw shapes, not always geojson, and he want to zoom in/out from an initial state.
I can't say that the initialZoom of the map will be the initial scale of the overlay.
The user could say that, not me.
So I have to let it him say it, and I have to say it to the overlay then.

By isolating this block, I can now.

Do you think it could be useful for others ?

I don't think it breaks anything, but I let you see that.

If you agree with this, I could change doc to add a section for the method `initHelperValues`.
